### PR TITLE
Dumper added 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 /target
 .vscode
+/dump

--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ Natiq Quran open API
 
 # Docker
 
-Start nq-api with docker-compose
+First get sql backup with dumper.py
 
 ```bash
-docker-compose up
+mkdir dump
+python3 dumper.py migrations/ dump/dump.sql
 ```
 
-Restore backup to the database with this command
+Then start nq-api with docker-compose
 
 ```bash
-cat init.sql | sudo docker exec -i {container_id} psql -U {username} -W -d {database}
+sudo docker compose up
 ```
-
-`init.sql` is a backup file of database
 
 # Build
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ docker-compose up
 Restore backup to the database with this command
 
 ```bash
-cat init.sql | sudo docker exec -i {container_id} psql -U {usename} -W -d {database}
+cat init.sql | sudo docker exec -i {container_id} psql -U {username} -W -d {database}
 ```
 
 `init.sql` is a backup file of database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,9 @@ services:
             POSTGRES_USER: username
             POSTGRES_PASSWORD: password
             POSTGRES_DB: base
+
+        healthcheck:
+            test: [ “CMD-SHELL”, “pg_isready” ]
+            interval: 1s
+            timeout: 5s
+            retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,6 @@ services:
             interval: 1s
             timeout: 5s
             retries: 10
+
+        volumes:
+            - ./dump:/docker-entrypoint-initdb.d

--- a/dumper.py
+++ b/dumper.py
@@ -1,0 +1,32 @@
+# (Natiq Api)
+# Collects the all migrations and pack to the one file
+# This script is works just with diesel.rs migration files
+# v0.0.1
+# by @AzerothA
+
+import sys
+import os
+
+def get_files_content(migrations_folder_path):
+    files = list(map(
+        lambda x: migrations_folder_path + x + "/" + os.listdir(migrations_folder_path + x)[1], 
+        os.listdir(migrations_folder_path)
+    ))
+
+    # now read all Up.sql files and put content into result string
+    content = "\n".join(list(map(lambda x: open(x, "r").read(), files)))
+
+    return content
+
+def main(args):
+    # Get the all sql
+    sql = get_files_content(args[1])
+
+    # now create the file
+    with open(args[2], "w") as result:
+       # Writing data to a file
+       result.write(sql)
+       result.close()
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
dumper collects all diesel migrations and put them into one SQL file.

# Usage
`python3 dumper.py [migrations folder] [target file]`

example:
`python3 dumper.py migrations/ dump.sql`

So with this update, you just need to run the command above, and docker-compose to get the app running as mentioned in the readme file.