### PR TITLE
New update to the auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -193,7 +193,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -248,13 +248,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -263,6 +263,8 @@ version = "0.0.1"
 dependencies = [
  "actix-utils",
  "actix-web",
+ "async-trait",
+ "futures-util",
  "sha2",
 ]
 
@@ -457,7 +459,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -474,7 +476,7 @@ checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -487,14 +489,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
 name = "diesel"
-version = "2.0.2"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c186a7418a2aac330bb76cde82f16c36b03a66fb91db32d20214311f9f6545"
+checksum = "72eb77396836a4505da85bae0712fa324b74acfe1876d7c2f7e694ef3d0ee373"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -507,14 +509,14 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b758c91dbc3fe1fdcb0dba5bd13276c6a66422f2ef5795b58488248a310aa"
+checksum = "0ad74fdcf086be3d4fdd142f67937678fe60ed431c3b2f08599e7687269410c4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1005,6 +1007,7 @@ version = "0.1.0"
 dependencies = [
  "actix-cors",
  "actix-web",
+ "async-trait",
  "auth",
  "chrono",
  "diesel",
@@ -1132,7 +1135,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "version_check",
 ]
 
@@ -1149,18 +1152,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1343,7 +1346,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1436,6 +1439,17 @@ name = "syn"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1657,7 +1671,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.103",
  "validator_types",
 ]
 
@@ -1668,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -1716,7 +1730,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1738,7 +1752,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,14 @@ name = "nq-api"
 version = "0.1.0"
 edition = "2021"
 
+[workspace]
+members = [".", "auth"]
+
 [dependencies]
-auth = { path="./auth" }
+auth = { path="auth" }
 actix-web = "4"
 actix-cors = "0.6.4"
-diesel = { version = "2.0.0", features = ["postgres", "r2d2", "chrono"] }
+diesel = { version = "2.0.4", features = ["postgres", "r2d2", "chrono"] }
 dotenvy = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
@@ -16,3 +19,4 @@ chrono = {version = "0.4", features = ["serde"]}
 lettre = { version = "0.10.1", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "hostname", "builder"] }
 validator = { version = "0.16.0", features = ["derive"] }
 diesel_migrations = "2.0.0"
+async-trait = "0.1.68"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 sha2 = "0.10.6"
 actix-web = "4"
 actix-utils = "3.0.1"
+async-trait = "0.1.68"
+futures-util = { version = "0.3.7", default-features = false, features = ["std"] }

--- a/auth/src/token/test.rs
+++ b/auth/src/token/test.rs
@@ -3,14 +3,14 @@ mod tests {
     use crate::token::token_middleware::TokenChecker;
     use crate::token::{TokenAuth, TokenGenerator};
     use actix_web::dev::Service;
-    use actix_web::http::{header};
+    use actix_web::http::header;
     use actix_web::test::{self, TestRequest};
     use actix_web::App;
 
     #[derive(Default, Clone)]
     struct FindToken;
 
-    impl TokenChecker for FindToken {
+    impl TokenChecker<bool> for FindToken {
         fn check_token(&self, _request_token: &str) -> bool {
             true
         }
@@ -39,7 +39,9 @@ mod tests {
 
         assert!(res.is_err());
 
-        let good_req = TestRequest::get().append_header((header::AUTHORIZATION, "secret-token")).to_request();
+        let good_req = TestRequest::get()
+            .append_header((header::AUTHORIZATION, "secret-token"))
+            .to_request();
 
         let res = app.call(good_req).await;
 

--- a/auth/src/token/token_middleware.rs
+++ b/auth/src/token/token_middleware.rs
@@ -1,4 +1,3 @@
-use actix_utils::future::{err, Either};
 use actix_utils::future::{ready, Ready};
 use actix_web::http::header;
 use actix_web::HttpMessage;
@@ -7,8 +6,16 @@ use actix_web::{
     error::ErrorUnauthorized,
     Error,
 };
+use async_trait::async_trait;
+use futures_util::future::LocalBoxFuture;
+use std::marker::PhantomData;
+use std::rc::Rc;
 
-pub trait TokenChecker {
+#[async_trait]
+pub trait TokenChecker<T>
+where
+    T: Sized
+{
     /// This function will return option
     /// if the request token valid return
     /// Some with sized data to pass to the router
@@ -16,7 +23,7 @@ pub trait TokenChecker {
     /// Unauthorized
     ///
     /// This function returns the verifyed user ID
-    fn get_user_id(&self, request_token: &str) -> Option<u32>
+    async fn get_user_id(&self, request_token: &str) -> Option<T>
     where
         Self: Sized;
 }
@@ -27,73 +34,90 @@ pub trait TokenChecker {
 // 2. Middleware's call method gets called with normal request.
 
 #[derive(Clone, Default)]
-pub struct TokenAuth<F>(F);
+pub struct TokenAuth<F, Type> {
+    finder: F,
+    phantom_type: PhantomData<Type>
+}
 
-impl<F> TokenAuth<F>
+impl<F, Type> TokenAuth<F, Type>
 where
-    F: TokenChecker,
+    F: TokenChecker<Type>,
+    Type: Sized
 {
     /// Construct `TokenAuth` middleware.
     pub fn new(finder: F) -> Self {
-        Self(finder)
+        Self {
+            finder,
+            phantom_type: PhantomData
+        }
     }
 }
 
 // Middleware factory is `Transform` trait from actix-service crate
 // `S` - type of the next service
 // `B` - type of response's body
-impl<S, B, F> Transform<S, ServiceRequest> for TokenAuth<F>
+impl<S, B, F, T> Transform<S, ServiceRequest> for TokenAuth<F, T>
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
     S::Future: 'static,
     B: 'static,
-    F: TokenChecker + Clone,
+    F: TokenChecker<T> + Clone + 'static,
+    T: Sized + 'static
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Transform = TokenAuthMiddleware<S, F>;
+    type Transform = TokenAuthMiddleware<S, F, T>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
         ready(Ok(TokenAuthMiddleware {
-            service,
-            token_finder: self.0.clone(),
+            service: Rc::new(service),
+            token_finder: self.finder.clone(),
+            phantom_type: PhantomData
         }))
     }
 }
 
-pub struct TokenAuthMiddleware<S, F> {
-    service: S,
+pub struct TokenAuthMiddleware<S, F, Type> {
+    service: Rc<S>,
     token_finder: F,
+    phantom_type: PhantomData<Type>,
 }
 
-impl<S, B, F> Service<ServiceRequest> for TokenAuthMiddleware<S, F>
+impl<S, B, F, Type> Service<ServiceRequest> for TokenAuthMiddleware<S, F, Type>
 where
-    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
     S::Future: 'static,
-    F: TokenChecker,
+    F: TokenChecker<Type> + Clone + 'static,
+    Type: Sized + 'static
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Future = Either<S::Future, Ready<Result<Self::Response, Self::Error>>>;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     forward_ready!(service);
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
-        if let Some(token) = req
-            .headers()
-            .get(header::AUTHORIZATION)
-            .and_then(|token| token.to_str().ok())
-        {
-            let token_data = self.token_finder.get_user_id(token);
+        let service = Rc::clone(&self.service);
+        let token_finder = self.token_finder.clone();
 
-            if let Some(data) = token_data {
-                req.extensions_mut().insert(data);
-                return Either::left(self.service.call(req));
-            };
-        }
+        Box::pin(async move {
+            if let Some(token) = req
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|token| token.to_str().ok())
+            {
+                let token_data = token_finder.get_user_id(token).await;
 
-        Either::right(err(ErrorUnauthorized("not authorized")))
+                if let Some(data) = token_data {
+                    req.extensions_mut().insert(data);
+                    let res = service.call(req).await.unwrap();
+                    return Ok(res);
+                };
+            }
+
+            Err(ErrorUnauthorized("This Token is not valid"))
+        })
     }
 }


### PR DESCRIPTION
From now on we use the async function inside the TokenChecker trait.
And we use `web::block` for db operations to prevent blocking.

And the TokenChecker requires the generic type to return it from the `get_user_id` function, so for example, now we can return the User permissions alongside the user id.

Closes #64