### PR TITLE
New uuid support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,6 +505,7 @@ dependencies = [
  "itoa",
  "pq-sys",
  "r2d2",
+ "uuid",
 ]
 
 [[package]]
@@ -1017,6 +1018,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "uuid",
  "validator",
 ]
 
@@ -1641,6 +1643,15 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding",
+]
+
+[[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ members = [".", "auth"]
 auth = { path="auth" }
 actix-web = "4"
 actix-cors = "0.6.4"
-diesel = { version = "2.0.4", features = ["postgres", "r2d2", "chrono"] }
+diesel = { version = "2.0.4", features = ["postgres", "r2d2", "chrono", "uuid"] }
+uuid = { version = "1.3.3", features = ["serde"] }
 dotenvy = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -34,3 +34,5 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/migrations/00000000000002_create_mushaf/up.sql
+++ b/migrations/00000000000002_create_mushaf/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE mushafs (
     id serial NOT NULL,
+    uuid uuid DEFAULT uuid_generate_v4 () NOT NULL,
     name VARCHAR(200),
     source VARCHAR(300),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/migrations/00000000000003_create_quran_surahs/up.sql
+++ b/migrations/00000000000003_create_quran_surahs/up.sql
@@ -1,7 +1,8 @@
 CREATE TABLE quran_surahs (
     id serial NOT NULL,
-    name VARCHAR(50) NOT NULL, 
-    period VARCHAR(50), 
+    uuid uuid DEFAULT uuid_generate_v4 () NOT NULL,
+    name VARCHAR(50) NOT NULL,
+    period VARCHAR(50),
     number serial NOT NULL,
     bismillah_status VARCHAR(10) NOT NULL,
     bismillah_text TEXT,

--- a/migrations/2023-02-19-100955_create_quran_ayahs/up.sql
+++ b/migrations/2023-02-19-100955_create_quran_ayahs/up.sql
@@ -1,6 +1,7 @@
 -- Your SQL goes here
 CREATE TABLE quran_ayahs (
     id serial NOT NULL,
+    uuid uuid DEFAULT uuid_generate_v4 () NOT NULL,
     surah_id serial NOT NULL,
     ayah_number serial NOT NULL,
     sajdeh VARCHAR(20),

--- a/migrations/2023-02-19-121254_create_quran_words/up.sql
+++ b/migrations/2023-02-19-121254_create_quran_words/up.sql
@@ -2,6 +2,7 @@
 
 CREATE TABLE quran_words(
     id serial NOT NULL,
+    uuid uuid DEFAULT uuid_generate_v4 () NOT NULL,
     ayah_id serial NOT NULL,
     word TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/migrations/2023-03-12-100253_create_translation/up.sql
+++ b/migrations/2023-03-12-100253_create_translation/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE translations (
     id serial NOT NULL,
+    uuid uuid DEFAULT uuid_generate_v4 (),
     translator_id serial NOT NULL,
     language VARCHAR(5) NOT NULL,
     release_year DATE,

--- a/migrations/2023-03-12-100301_create_translation_text/up.sql
+++ b/migrations/2023-03-12-100301_create_translation_text/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE translations_text (
     id serial NOT NULL,
+    uuid uuid DEFAULT uuid_generate_v4 (),
     translation_id serial NOT NULL,
     ayah_id serial NOT NULL,
     text TEXT NOT NULL,

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,6 +2,7 @@ use crate::schema::*;
 use chrono::{NaiveDate, NaiveDateTime};
 use diesel::{Associations, Identifiable, Insertable, Queryable, Selectable};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 use validator::Validate;
 
 #[derive(Identifiable, Queryable, Debug, Serialize)]
@@ -167,7 +168,11 @@ pub struct NewEmployee {
 #[diesel(belongs_to(QuranSurah, foreign_key = surah_id))]
 #[diesel(table_name = quran_ayahs)]
 pub struct QuranAyah {
+    #[serde(skip_serializing)]
     pub id: i32,
+
+    pub uuid: Uuid,
+
     #[serde(skip_serializing)]
     pub surah_id: i32,
 
@@ -184,7 +189,10 @@ pub struct QuranAyah {
 #[diesel(belongs_to(QuranAyah, foreign_key = ayah_id))]
 #[diesel(table_name = quran_words)]
 pub struct QuranWord {
+    #[serde(skip_serializing)]
     pub id: i32,
+
+    pub uuid: Uuid,
 
     #[serde(skip_serializing)]
     pub ayah_id: i32,
@@ -197,13 +205,14 @@ pub struct QuranWord {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(
-    Serialize, Clone, Insertable, Deserialize, Validate, Identifiable, Queryable, Selectable, Debug,
-)]
+#[derive(Deserialize, Serialize, Clone, Validate, Identifiable, Queryable, Selectable, Debug)]
 #[diesel(belongs_to(QuranMushaf, foreign_key = mushaf_id))]
 #[diesel(table_name = quran_surahs)]
 pub struct QuranSurah {
+    #[serde(skip_serializing)]
     pub id: i32,
+
+    pub uuid: Uuid,
 
     pub name: String,
     pub period: Option<String>,
@@ -218,12 +227,13 @@ pub struct QuranSurah {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(
-    Serialize, Clone, Insertable, Deserialize, Validate, Identifiable, Queryable, Selectable, Debug,
-)]
+#[derive(Deserialize, Serialize, Clone, Validate, Identifiable, Queryable, Selectable, Debug)]
 #[diesel(table_name = mushafs)]
 pub struct QuranMushaf {
+    #[serde(skip_serializing)]
     pub id: i32,
+
+    pub uuid: Uuid,
 
     pub name: Option<String>,
     pub source: Option<String>,

--- a/src/routers/quran/surah.rs
+++ b/src/routers/quran/surah.rs
@@ -8,6 +8,7 @@ use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::hash::Hash;
+use uuid::Uuid;
 
 /// finds the relatives in the vector
 /// Vec<(Obj1, Obj2)>
@@ -39,7 +40,7 @@ pub struct SurahListQuery {
 
 #[derive(Serialize, Queryable, Clone, Debug)]
 pub struct SimpleSurah {
-    pub id: i32,
+    pub uuid: Uuid,
     pub name: String,
     pub period: Option<String>,
     pub number: i32,
@@ -64,7 +65,7 @@ pub async fn surahs_list(
 
         // Select the specific mushaf
         // and check if it exists
-        let Ok(mushaf)=
+        let Ok(mushaf) =
             mushafs.filter(mushaf_name.eq(&query.mushaf))
             .get_result::<QuranMushaf>(&mut conn)
         else {
@@ -95,7 +96,7 @@ pub async fn surahs_list(
             .into_iter()
             .zip(ayahs)
             .map(|(surah, number_of_ayahs)| SimpleSurah {
-                id: surah.id,
+                uuid: surah.uuid,
                 name: surah.name,
                 number: surah.number,
                 period: surah.period,
@@ -141,7 +142,7 @@ enum AyahTextType {
 
 #[derive(PartialOrd, Ord, Eq, Hash, PartialEq, Serialize, Clone, Debug)]
 pub struct SimpleAyah {
-    id: i32,
+    uuid: Uuid,
     number: i32,
     sajdeh: Option<String>,
 }
@@ -200,7 +201,7 @@ pub async fn surah(
 
         let ayahs_as_map: BTreeMap<SimpleAyah, Vec<QuranWord>> =
             multip(result, |ayah| SimpleAyah {
-                id: ayah.id,
+                uuid: ayah.uuid,
                 number: ayah.ayah_number,
                 sajdeh: ayah.sajdeh,
             });
@@ -231,7 +232,7 @@ pub async fn surah(
 
         Ok(web::Json(QuranResponseData {
             surah: SimpleSurah {
-                id: surah.id,
+                uuid: surah.uuid,
                 name: surah.name,
                 period: surah.period,
                 number: surah.number,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -83,6 +83,7 @@ diesel::table! {
 diesel::table! {
     mushafs (id) {
         id -> Int4,
+        uuid -> Uuid,
         name -> Nullable<Varchar>,
         source -> Nullable<Varchar>,
         created_at -> Timestamptz,
@@ -93,6 +94,7 @@ diesel::table! {
 diesel::table! {
     quran_ayahs (id) {
         id -> Int4,
+        uuid -> Uuid,
         surah_id -> Int4,
         ayah_number -> Int4,
         sajdeh -> Nullable<Varchar>,
@@ -104,6 +106,7 @@ diesel::table! {
 diesel::table! {
     quran_surahs (id) {
         id -> Int4,
+        uuid -> Uuid,
         name -> Varchar,
         period -> Nullable<Varchar>,
         number -> Int4,
@@ -118,6 +121,7 @@ diesel::table! {
 diesel::table! {
     quran_words (id) {
         id -> Int4,
+        uuid -> Uuid,
         ayah_id -> Int4,
         word -> Text,
         created_at -> Timestamptz,
@@ -128,6 +132,7 @@ diesel::table! {
 diesel::table! {
     translations (id) {
         id -> Int4,
+        uuid -> Nullable<Uuid>,
         translator_id -> Int4,
         language -> Varchar,
         release_year -> Nullable<Date>,
@@ -140,6 +145,7 @@ diesel::table! {
 diesel::table! {
     translations_text (id) {
         id -> Int4,
+        uuid -> Nullable<Uuid>,
         translation_id -> Int4,
         ayah_id -> Int4,
         text -> Text,


### PR DESCRIPTION
Our Quran-related tables have a UUID column that we can return in the response because we need to identify the selected surah, ayah, or word. As the user selects one of these, the client will send the UUID back to the backend to get the full information about it.
Closes #57