### PR TITLE
New user_names 

### DIFF
--- a/auth/src/token/token_middleware.rs
+++ b/auth/src/token/token_middleware.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 #[async_trait]
 pub trait TokenChecker<T>
 where
-    T: Sized
+    T: Sized,
 {
     /// This function will return option
     /// if the request token valid return
@@ -36,19 +36,19 @@ where
 #[derive(Clone, Default)]
 pub struct TokenAuth<F, Type> {
     finder: F,
-    phantom_type: PhantomData<Type>
+    phantom_type: PhantomData<Type>,
 }
 
 impl<F, Type> TokenAuth<F, Type>
 where
     F: TokenChecker<Type>,
-    Type: Sized
+    Type: Sized,
 {
     /// Construct `TokenAuth` middleware.
     pub fn new(finder: F) -> Self {
         Self {
             finder,
-            phantom_type: PhantomData
+            phantom_type: PhantomData,
         }
     }
 }
@@ -62,7 +62,7 @@ where
     S::Future: 'static,
     B: 'static,
     F: TokenChecker<T> + Clone + 'static,
-    T: Sized + 'static
+    T: Sized + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
@@ -74,7 +74,7 @@ where
         ready(Ok(TokenAuthMiddleware {
             service: Rc::new(service),
             token_finder: self.finder.clone(),
-            phantom_type: PhantomData
+            phantom_type: PhantomData,
         }))
     }
 }
@@ -90,7 +90,7 @@ where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
     S::Future: 'static,
     F: TokenChecker<Type> + Clone + 'static,
-    Type: Sized + 'static
+    Type: Sized + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;

--- a/migrations/2022-10-24-095557_create_app_user/up.sql
+++ b/migrations/2022-10-24-095557_create_app_user/up.sql
@@ -1,10 +1,9 @@
 CREATE TABLE app_users (
     id serial NOT NULL,
     account_id serial NOT NULL,
-    first_name VARCHAR(30),
-    last_name VARCHAR(30),
     birthday DATE,
     profile_image TEXT,
+    language VARCHAR(4) DEFAULT 'en',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT app_users_id PRIMARY KEY (id),

--- a/migrations/2022-12-27-171201_create_app_organizations/up.sql
+++ b/migrations/2022-12-27-171201_create_app_organizations/up.sql
@@ -3,7 +3,6 @@
 CREATE TABLE app_organizations(
     id serial NOT NULL,
     account_id serial NOT NULL,
-    "name" VARCHAR(200) NOT NULL,
     profile_image TEXT,
     established_date DATE NOT NULL,
     national_id VARCHAR(11) NOT NULL,

--- a/migrations/2023-05-25-072843_create_app_user_names/down.sql
+++ b/migrations/2023-05-25-072843_create_app_user_names/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE app_user_names;

--- a/migrations/2023-05-25-072843_create_app_user_names/up.sql
+++ b/migrations/2023-05-25-072843_create_app_user_names/up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE app_user_names(
+    id serial NOT NULL,
+    account_id serial NOT NULL,
+    primary_name boolean NOT NULL,
+    first_name VARCHAR(100) NOT NULL,
+    last_name VARCHAR(200) NOT NULL,
+    language VARCHAR(4) NOT NULL,
+    CONSTRAINT fk_user_names_account_id FOREIGN KEY(account_id) REFERENCES app_accounts(id),
+    CONSTRAINT user_names_id PRIMARY KEY (id)
+);

--- a/migrations/2023-05-26-131146_create_app_organization_names/down.sql
+++ b/migrations/2023-05-26-131146_create_app_organization_names/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE app_organization_names;

--- a/migrations/2023-05-26-131146_create_app_organization_names/up.sql
+++ b/migrations/2023-05-26-131146_create_app_organization_names/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE app_organization_names (
+    id serial NOT NULL,
+    account_id serial NOT NULL,
+    primary_name boolean NOT NULL,
+    name VARCHAR(300) NOT NULL,
+    language VARCHAR(4) NOT NULL,
+    CONSTRAINT fk_org_names_account_id FOREIGN KEY(account_id) REFERENCES app_accounts(id),
+    CONSTRAINT org_names_id PRIMARY KEY (id)
+);

--- a/src/models.rs
+++ b/src/models.rs
@@ -20,6 +20,28 @@ pub struct NewAccount<'a> {
     pub account_type: &'a String,
 }
 
+#[derive(Clone, Identifiable, Queryable, Debug, Serialize, Associations)]
+#[diesel(belongs_to(Account))]
+#[diesel(table_name = app_user_names)]
+pub struct UserName {
+    pub id: i32,
+    pub account_id: i32,
+    pub primary: bool,
+    pub first_name: String,
+    pub last_name: String,
+    pub language: String,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = app_user_names)]
+pub struct NewUserNames {
+    pub account_id: i32,
+    pub primary_name: bool,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub language: Option<String>,
+}
+
 #[derive(Identifiable, Queryable, Debug)]
 #[diesel(table_name = app_verify_codes)]
 pub struct VerifyCode {
@@ -45,10 +67,9 @@ pub struct NewVerifyCode<'a> {
 pub struct User {
     pub id: i32,
     pub account_id: i32,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
     pub birthday: Option<NaiveDate>,
     pub profile_image: Option<String>,
+    pub language: Option<String>,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -60,12 +81,14 @@ pub struct UserProfile {
     pub last_name: Option<String>,
     pub birthday: Option<NaiveDate>,
     pub profile_image: Option<String>,
+    pub language: String,
 }
 
 #[derive(Insertable)]
 #[diesel(table_name = app_users)]
 pub struct NewUser {
     pub account_id: i32,
+    pub language: Option<String>,
 }
 
 // TODO: use belongs to

--- a/src/routers/account/test.rs
+++ b/src/routers/account/test.rs
@@ -45,7 +45,6 @@ mod tests {
         assert_eq!(res.status(), StatusCode::OK);
 
         assert_eq!(res.response().body().size(), BodySize::Sized(11));
-
     }
 
     /// TODO:

--- a/src/routers/account/verify.rs
+++ b/src/routers/account/verify.rs
@@ -50,7 +50,6 @@ pub async fn verify(
             ));
         };
 
-
         // The code is not correct
         if last_sended_code.code != info.code {
             return Ok("Code is not correct".to_string());
@@ -103,6 +102,7 @@ pub async fn verify(
 
             let Ok(new_user)= NewUser {
                 account_id: new_account.id,
+                language: None,
             }
             .insert_into(app_users::dsl::app_users)
             .get_result::<User>(&mut conn)

--- a/src/routers/profile/edit_profile.rs
+++ b/src/routers/profile/edit_profile.rs
@@ -7,6 +7,7 @@ use crate::{
     DbPool,
 };
 
+// TODO: Create a router for handling names
 /// Edit the profile
 /// wants a new profile and token
 pub async fn edit_profile(
@@ -53,8 +54,8 @@ pub async fn edit_profile(
         // And update the other data
         let Ok(_) = diesel::update(current_user_profile)
             .set((
-                first_name.eq(new_profile.first_name),
-                last_name.eq(new_profile.last_name),
+                // first_name.eq(new_profile.first_name),
+                // last_name.eq(new_profile.last_name),
                 birthday.eq(new_profile.birthday),
                 profile_image.eq(new_profile.profile_image),
             ))

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -57,13 +57,23 @@ diesel::table! {
 }
 
 diesel::table! {
+    app_user_names (id) {
+        id -> Int4,
+        account_id -> Int4,
+        primary_name -> Bool,
+        first_name -> Varchar,
+        last_name -> Varchar,
+        language -> Varchar,
+    }
+}
+
+diesel::table! {
     app_users (id) {
         id -> Int4,
         account_id -> Int4,
-        first_name -> Nullable<Varchar>,
-        last_name -> Nullable<Varchar>,
         birthday -> Nullable<Date>,
         profile_image -> Nullable<Text>,
+        language -> Nullable<Varchar>,
         created_at -> Timestamptz,
         updated_at -> Timestamptz,
     }
@@ -157,6 +167,7 @@ diesel::table! {
 diesel::joinable!(app_employees -> app_accounts (employee_account_id));
 diesel::joinable!(app_organizations -> app_accounts (account_id));
 diesel::joinable!(app_tokens -> app_accounts (terminated_by_id));
+diesel::joinable!(app_user_names -> app_accounts (account_id));
 diesel::joinable!(quran_ayahs -> quran_surahs (surah_id));
 diesel::joinable!(quran_surahs -> mushafs (mushaf_id));
 diesel::joinable!(quran_words -> quran_ayahs (ayah_id));
@@ -169,6 +180,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     app_employees,
     app_organizations,
     app_tokens,
+    app_user_names,
     app_users,
     app_verify_codes,
     mushafs,


### PR DESCRIPTION
We want a good UX in terms of translations or language support of the app, so we decided to create multi-language names, this means that some verified users can set multiple names for multiple languages so users from different countries be able to spell their names.

for example, we have a user called 爱丽丝 but it's not readable in English, so the user creates another name for instance English, the equivalent to this Chinese name is Alice.

currently, the app is not supporting this feature completely yet.