### PR TITLE
New update to Difference Module, and AuthZ

### DIFF
--- a/authZ/src/lib.rs
+++ b/authZ/src/lib.rs
@@ -22,7 +22,7 @@ pub trait CheckPermission {
     /// Check if the permissions are valid
     ///
     /// This args will passed from the Middleware
-    async fn check(&self, subject: String, path: ParsedPath, method: String) -> bool;
+    async fn check(&self, subject: Option<u32>, path: ParsedPath, method: String) -> bool;
 }
 
 #[async_trait]

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -1,5 +1,45 @@
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
 
+/// Returns the key of an object
+/// Kind of the name of *existing* object
+///
+/// Mostly used to identify these items in hashmap's
+pub trait GetKey {
+    fn get_key(&self) -> String
+    where
+        Self: Sized;
+}
+
+pub struct DifferenceContext<T>
+where
+    T: GetKey,
+{
+    target: HashMap<String, T>,
+    new: Vec<(String, T)>,
+}
+
+impl<T> DifferenceContext<T>
+where
+    T: GetKey,
+{
+    /// Creates a new Context
+    pub fn new(target: Vec<T>, new: Vec<T>) -> Self {
+        let mut target_map: HashMap<String, T> = HashMap::new();
+
+        for item in target {
+            target_map.insert(item.get_key(), item);
+        }
+
+        let new_difference_compatible: Vec<(String, T)> =
+            new.into_iter().map(|item| (item.get_key(), item)).collect();
+
+        Self {
+            target: target_map,
+            new: new_difference_compatible,
+        }
+    }
+}
+
 /// The final result of Diff
 ///
 /// So the dev can know When to update
@@ -18,39 +58,70 @@ pub enum DifferenceResult<T> {
     /// Removed Data
     Remove(T),
 }
+
 /// Finds the difference between Two Vectors
-pub struct Difference<'a, T>
+pub struct Difference<T>
 where
     T: Hash + Eq + PartialEq,
 {
-    target: HashMap<&'a str, T>,
-    new: &'a [(&'a str, T)],
+    target: HashMap<String, T>,
+    new: Vec<(String, T)>,
 }
 
-impl<'a, T> Difference<'a, T>
+impl<T> Difference<T>
 where
-    T: Hash + Eq + PartialEq + Sized + Ord + Debug,
+    T: Hash + Eq + PartialEq + Sized + Clone,
 {
     /// Creates a new Diff Object
-    pub fn new(target: HashMap<&'a str, T>, new: &'a [(&'a str, T)]) -> Self {
+    pub fn new(target: HashMap<String, T>, new: Vec<(String, T)>) -> Self {
         Self { new, target }
     }
 
-    pub fn diff(&self) -> Vec<DifferenceResult<&T>> {
+    /// Found's the difference between two seprate Vec's
+    pub fn diff(&mut self) -> Vec<DifferenceResult<T>> {
         let mut result = vec![];
 
-        for (name, object) in self.new {
-            match self.target.get(name) {
+        for (name, object) in self.new.to_owned() {
+            match self.target.remove(&name) {
                 Some(i) => {
+                    // Check if objects in equal (checking hash)
                     if i != object {
+                        // If not then this is a update state
                         result.push(DifferenceResult::Update(i, object));
                     }
+
+                    // Else we ignore it (there is no change)
                 }
+
+                // there is nothing like that
+                //
+                // then this is a new data
                 None => result.push(DifferenceResult::Insert(object)),
             }
         }
 
+        // Get the remaining data from target and turn them into
+        // DifferenceResult
+        let remaining_as_remove: Vec<DifferenceResult<T>> = self
+            .target
+            .to_owned()
+            .into_iter()
+            .map(|(_, item)| DifferenceResult::Remove(item))
+            .collect();
+
+        result.extend(remaining_as_remove);
+
         result
+    }
+}
+
+/// Construct Difference from DifferenceContext
+impl<T> From<DifferenceContext<T>> for Difference<T>
+where
+    T: Hash + Eq + PartialEq + Sized + Clone + GetKey,
+{
+    fn from(value: DifferenceContext<T>) -> Self {
+        Self::new(value.target, value.new)
     }
 }
 
@@ -58,67 +129,138 @@ where
 mod tests {
     use super::*;
 
-    #[derive(Hash, Ord, Eq, PartialEq, Debug, PartialOrd)]
+    #[derive(Hash, Eq, PartialEq, Debug, PartialOrd, Clone)]
     struct TestData<'a> {
         name: &'a str,
         value: &'a str,
     }
 
-    #[test]
-    fn test_diff() {
-        let target = HashMap::from([
-            (
-                "Hello",
-                TestData {
-                    name: "Hello",
-                    value: "true",
-                },
-            ),
-            (
-                "OkMa",
-                TestData {
-                    name: "OOK",
-                    value: "OOK",
-                },
-            ),
-        ]);
+    impl<'a> GetKey for TestData<'a> {
+        fn get_key(&self) -> String {
+            self.name.to_string()
+        }
+    }
 
-        let new = vec![
-            (
-                "Hello",
-                TestData {
-                    name: "Hello",
-                    value: "false",
-                },
-            ),
-            (
-                "Ok",
-                TestData {
-                    name: "Ok",
-                    value: "test",
-                },
-            ),
+    #[test]
+    fn test_diff_with_update_insert_remove() {
+        let target = vec![
+            TestData {
+                name: "Hello",
+                value: "true",
+            },
+            TestData {
+                name: "OOK",
+                value: "OOK",
+            },
         ];
 
-        let diff = Difference::new(target, &new);
+        let new = vec![
+            TestData {
+                name: "Hello",
+                value: "false",
+            },
+            TestData {
+                name: "Ok",
+                value: "test",
+            },
+        ];
+
+        let context = DifferenceContext::new(target, new);
+        let mut diff = Difference::from(context);
         let result = diff.diff();
 
         let expected = vec![
             DifferenceResult::Update(
-                &TestData {
+                TestData {
                     name: "Hello",
                     value: "true",
                 },
-                &TestData {
+                TestData {
                     name: "Hello",
                     value: "false",
                 },
             ),
-            DifferenceResult::Insert(&TestData {
+            DifferenceResult::Insert(TestData {
                 name: "Ok",
                 value: "test",
             }),
+            DifferenceResult::Remove(TestData {
+                name: "OOK",
+                value: "OOK",
+            }),
         ];
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_diff_with_insert() {
+        let target = vec![];
+
+        let new = vec![TestData {
+            name: "Hello",
+            value: "false",
+        }];
+
+        let context = DifferenceContext::new(target, new);
+        let mut diff = Difference::from(context);
+        let result = diff.diff();
+
+        let expected = vec![DifferenceResult::Insert(TestData {
+            name: "Hello",
+            value: "false",
+        })];
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_diff_with_update() {
+        let target = vec![TestData {
+            name: "Hello",
+            value: "false",
+        }];
+
+        let new = vec![TestData {
+            name: "Hello",
+            value: "true",
+        }];
+
+        let context = DifferenceContext::new(target, new);
+        let mut diff = Difference::from(context);
+        let result = diff.diff();
+
+        let expected = vec![DifferenceResult::Update(
+            TestData {
+                name: "Hello",
+                value: "false",
+            },
+            TestData {
+                name: "Hello",
+                value: "true",
+            },
+        )];
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_diff_with_remove() {
+        let target = vec![TestData {
+            name: "Hello",
+            value: "false",
+        }];
+
+        let new = vec![];
+
+        let context = DifferenceContext::new(target, new);
+        let mut diff = Difference::from(context);
+        let result = diff.diff();
+
+        let expected = vec![DifferenceResult::Remove(TestData {
+            name: "Hello",
+            value: "false",
+        })];
 
         assert_eq!(expected, result);
     }

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, fmt::Debug, hash::Hash};
 /// So the dev can know When to update
 /// ,insert or delete item
 #[derive(Debug, PartialEq)]
-pub enum Difference<T> {
+pub enum DifferenceResult<T> {
     /// Update the existing Data
     ///
     /// First T is target and second is
@@ -19,7 +19,7 @@ pub enum Difference<T> {
     Remove(T),
 }
 /// Finds the difference between Two Vectors
-pub struct Diff<'a, T>
+pub struct Difference<'a, T>
 where
     T: Hash + Eq + PartialEq,
 {
@@ -27,7 +27,7 @@ where
     new: &'a [(&'a str, T)],
 }
 
-impl<'a, T> Diff<'a, T>
+impl<'a, T> Difference<'a, T>
 where
     T: Hash + Eq + PartialEq + Sized + Ord + Debug,
 {
@@ -36,17 +36,17 @@ where
         Self { new, target }
     }
 
-    pub fn diff(&self) -> Vec<Difference<&T>> {
+    pub fn diff(&self) -> Vec<DifferenceResult<&T>> {
         let mut result = vec![];
 
         for (name, object) in self.new {
             match self.target.get(name) {
                 Some(i) => {
                     if i != object {
-                        result.push(Difference::Update(i, object));
+                        result.push(DifferenceResult::Update(i, object));
                     }
                 }
-                None => result.push(Difference::Insert(object)),
+                None => result.push(DifferenceResult::Insert(object)),
             }
         }
 
@@ -100,11 +100,11 @@ mod tests {
             ),
         ];
 
-        let diff = Diff::new(target, &new);
+        let diff = Difference::new(target, &new);
         let result = diff.diff();
 
         let expected = vec![
-            Difference::Update(
+            DifferenceResult::Update(
                 &TestData {
                     name: "Hello",
                     value: "true",
@@ -114,13 +114,12 @@ mod tests {
                     value: "false",
                 },
             ),
-            Difference::Insert(&TestData {
+            DifferenceResult::Insert(&TestData {
                 name: "Ok",
                 value: "test",
             }),
         ];
 
-        
         assert_eq!(expected, result);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod test;
 mod token_checker;
 mod validate;
 
-mod diff;
+mod difference;
 mod macros;
 
 use routers::account::logout;


### PR DESCRIPTION
New changes :

1. Now Remove DifferenceResult works, and the Difference module now detects the deletion.
2. Now AuthZ middleware does not require the subject ID and that can be an option, in other words, the AuthZ middleware doesn't depend on AuthN (tokenChecker) anymore.
3. New Test cases have been written for the Difference Module, A test case for every possible DifferenceResult (almost).
4. New DifferenceContext struct added to simplify Difference struct Construction.
5. A new interface was added to get the key (name) of the Objects, and it has only one function `get_key`, that returns the key of an object from the object itself, for example, the key of the object `TestObject {name: "helloObj", value: "true"}` is object.name (helloObj).