### PR TITLE
`<'a>` lifetime annotation changed to `'static`

### DIFF
--- a/src/routers/organization/add.rs
+++ b/src/routers/organization/add.rs
@@ -13,11 +13,11 @@ use crate::{
 use super::new_organization_info::NewOrgInfo;
 
 /// Add a new Org
-pub async fn add<'a>(
+pub async fn add(
     conn: web::Data<DbPool>,
     new_org: web::Json<NewOrgInfo>,
     data: ReqData<u32>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_accounts::dsl::*;
     use crate::schema::app_employees::dsl::app_employees;
     use crate::schema::app_organization_names::dsl::app_organization_names;
@@ -29,7 +29,7 @@ pub async fn add<'a>(
 
     validate(&new_org_info)?;
 
-    let result: Result<&'a str, RouterError> = web::block(move || {
+    let result: Result<&'static str, RouterError> = web::block(move || {
         let mut conn = conn.get().unwrap();
 
         // Check if org already exists

--- a/src/routers/organization/delete.rs
+++ b/src/routers/organization/delete.rs
@@ -7,10 +7,10 @@ use actix_web::web;
 use diesel::prelude::*;
 
 /// Delete's a single organization
-pub async fn delete_organization<'a>(
+pub async fn delete_organization(
     path: web::Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_accounts::dsl::{app_accounts, id as acc_id, uuid as account_uuid};
     use crate::schema::app_organizations::dsl::{account_id as org_acc_id, app_organizations};
 

--- a/src/routers/organization/edit.rs
+++ b/src/routers/organization/edit.rs
@@ -23,7 +23,7 @@ pub async fn edit_organization(
     path: web::Path<String>,
     info: web::Json<OrgInfoUpdatebleFileds>,
     pool: web::Data<DbPool>,
-) -> Result<String, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_accounts::dsl::{app_accounts, username, uuid as acc_uuid};
     use crate::schema::app_organization_names::dsl::{language, name};
     use crate::schema::app_organizations::dsl::*;
@@ -33,7 +33,7 @@ pub async fn edit_organization(
     //let user_id = user_id.into_inner();
     let new_org = info.into_inner();
 
-    let update_result: Result<String, RouterError> = web::block(move || {
+    let update_result: Result<&'static str, RouterError> = web::block(move || {
         let mut conn = pool.get().unwrap();
 
         let account_uuid = Uuid::from_str(&account_uuid)?;
@@ -69,7 +69,7 @@ pub async fn edit_organization(
             .set((name.eq(new_org.name),))
             .execute(&mut conn)?;
 
-        Ok("Updated".to_string())
+        Ok("Updated")
     })
     .await
     .unwrap();

--- a/src/routers/permission/add_permission.rs
+++ b/src/routers/permission/add_permission.rs
@@ -9,11 +9,11 @@ use crate::models::User;
 
 use super::NewPermissionData;
 
-pub async fn add_permission<'a>(
+pub async fn add_permission(
     data: web::ReqData<u32>,
     new_permission: web::Json<NewPermissionData>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_permission_conditions::dsl::app_permission_conditions;
     use crate::schema::app_permissions::dsl::app_permissions;
     use crate::schema::app_users::dsl::{app_users, account_id as user_acc_id};

--- a/src/routers/permission/delete_permission.rs
+++ b/src/routers/permission/delete_permission.rs
@@ -6,10 +6,10 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 /// Cascade delete permission
-pub async fn delete_permission<'a>(
+pub async fn delete_permission(
     target_permission: Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_permissions::dsl::{app_permissions, uuid as uuid_from_permission};
 
     let target_permission = target_permission.into_inner();

--- a/src/routers/permission/edit_permission.rs
+++ b/src/routers/permission/edit_permission.rs
@@ -19,12 +19,12 @@ use super::NewPermissionData;
 /// On updating the conditions this router will
 /// remove all related conditions, and insert the new ones
 /// this solution is kind of stupid but it's really simple.
-pub async fn edit_permission<'a>(
+pub async fn edit_permission(
     target_permission: Path<String>,
     new_permission: web::Json<NewPermissionData>,
     pool: web::Data<DbPool>,
     data: web::ReqData<u32>
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_permission_conditions::dsl::{
         app_permission_conditions, id as condition_id, name as condition_name,
         value as condition_value,
@@ -38,7 +38,7 @@ pub async fn edit_permission<'a>(
     let new_permission = new_permission.into_inner();
     let data = data.into_inner();
 
-    let result: Result<&'a str, RouterError> = web::block(move || {
+    let result: Result<&'static str, RouterError> = web::block(move || {
         let mut conn = pool.get().unwrap();
         let permission_uuid = Uuid::from_str(&target_permission)?;
 

--- a/src/routers/quran/ayah/ayah_delete.rs
+++ b/src/routers/quran/ayah/ayah_delete.rs
@@ -7,10 +7,10 @@ use actix_web::web;
 use diesel::prelude::*;
 
 /// Delete's a single ayah
-pub async fn ayah_delete<'a>(
+pub async fn ayah_delete(
     path: web::Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::quran_ayahs::dsl::{quran_ayahs, uuid as ayah_uuid};
 
     let path = path.into_inner();

--- a/src/routers/quran/ayah/ayah_edit.rs
+++ b/src/routers/quran/ayah/ayah_edit.rs
@@ -9,11 +9,11 @@ use uuid::Uuid;
 use super::SimpleAyah;
 
 /// Update's single ayah
-pub async fn ayah_edit<'a>(
+pub async fn ayah_edit(
     path: web::Path<String>,
     new_ayah: web::Json<SimpleAyah>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::quran_ayahs::dsl::{
         ayah_number, quran_ayahs, sajdeh as ayah_sajdeh,
         surah_id as ayah_surah_id, uuid as ayah_uuid,

--- a/src/routers/quran/mushaf/mushaf_add.rs
+++ b/src/routers/quran/mushaf/mushaf_add.rs
@@ -7,11 +7,11 @@ use diesel::prelude::*;
 use super::SimpleMushaf;
 
 /// Add's new mushaf
-pub async fn mushaf_add<'a>(
+pub async fn mushaf_add(
     new_mushaf: web::Json<SimpleMushaf>,
     pool: web::Data<DbPool>,
     data: web::ReqData<u32>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::mushafs::dsl::mushafs;
     use crate::schema::app_users::dsl::{app_users, account_id as user_acc_id};
 

--- a/src/routers/quran/mushaf/mushaf_delete.rs
+++ b/src/routers/quran/mushaf/mushaf_delete.rs
@@ -7,10 +7,10 @@ use actix_web::web;
 use diesel::prelude::*;
 
 /// Delete's a single mushaf
-pub async fn mushaf_delete<'a>(
+pub async fn mushaf_delete(
     path: web::Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::mushafs::dsl::{mushafs, uuid as mushaf_uuid};
 
     let path = path.into_inner();

--- a/src/routers/quran/mushaf/mushaf_edit.rs
+++ b/src/routers/quran/mushaf/mushaf_edit.rs
@@ -9,11 +9,11 @@ use uuid::Uuid;
 use super::SimpleMushaf;
 
 /// Update's single mushaf
-pub async fn mushaf_edit<'a>(
+pub async fn mushaf_edit(
     path: web::Path<String>,
     new_mushaf: web::Json<SimpleMushaf>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::mushafs::dsl::{
         bismillah_text, mushafs, name as mushaf_name, source as mushaf_source, uuid as mushaf_uuid,
     };

--- a/src/routers/quran/surah/surah_add.rs
+++ b/src/routers/quran/surah/surah_add.rs
@@ -8,11 +8,11 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 // Add's and new surah
-pub async fn surah_add<'a>(
+pub async fn surah_add(
     new_surah: web::Json<SimpleSurah>,
     pool: web::Data<DbPool>,
     data: web::ReqData<u32>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::mushafs::dsl::{id as mushaf_id, mushafs, uuid as mushaf_uuid};
     use crate::schema::quran_surahs::dsl::quran_surahs;
     use crate::schema::app_users::dsl::{app_users, account_id as user_acc_id};

--- a/src/routers/quran/surah/surah_delete.rs
+++ b/src/routers/quran/surah/surah_delete.rs
@@ -6,10 +6,10 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 /// Delete's the specific surah
-pub async fn surah_delete<'a>(
+pub async fn surah_delete(
     path: web::Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::quran_surahs::dsl::{quran_surahs, uuid as surah_uuid};
 
     let path = path.into_inner();

--- a/src/routers/quran/surah/surah_edit.rs
+++ b/src/routers/quran/surah/surah_edit.rs
@@ -9,11 +9,11 @@ use uuid::Uuid;
 use super::SimpleSurah;
 
 /// Update's single surah
-pub async fn surah_edit<'a>(
+pub async fn surah_edit(
     path: web::Path<String>,
     new_surah: web::Json<SimpleSurah>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::mushafs::dsl::{id as mushaf_id, mushafs, uuid as mushaf_uuid};
     use crate::schema::quran_surahs::dsl::{
         bismillah_status, bismillah_as_first_ayah, mushaf_id as surah_mushaf_id, name, number, period, quran_surahs,

--- a/src/routers/translation/translation_edit.rs
+++ b/src/routers/translation/translation_edit.rs
@@ -7,11 +7,11 @@ use uuid::Uuid;
 use super::SimpleTranslation;
 
 /// Update's single Translation
-pub async fn translation_edit<'a>(
+pub async fn translation_edit(
     path: web::Path<Uuid>,
     new_translation: web::Json<SimpleTranslation>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::translations::dsl::{
         language as translation_language, release_date as translation_release_date,
         source as translation_source, translations, uuid as translation_uuid,

--- a/src/routers/user/delete_user.rs
+++ b/src/routers/user/delete_user.rs
@@ -7,10 +7,10 @@ use actix_web::web;
 use diesel::prelude::*;
 
 /// Delete's a single user
-pub async fn delete_user<'a>(
+pub async fn delete_user(
     path: web::Path<String>,
     pool: web::Data<DbPool>,
-) -> Result<&'a str, RouterError> {
+) -> Result<&'static str, RouterError> {
     use crate::schema::app_accounts::dsl::{app_accounts, id as acc_id, uuid as acc_uuid};
     use crate::schema::app_users::dsl::{account_id as user_acc_id, app_users};
 


### PR DESCRIPTION
We do not need to specify a `<'a>` lifetime for functions, when we use `'&static str`, The str with a static lifetime will live until the end of the program, These types of str's that we used in routers, is not saved In memory instead it's held in the application binary.