### PR TITLE
Filters update

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,23 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-/// Sort (SortBy)
-#[derive(Deserialize, Serialize, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum Sort {
-    /// Sort by number
-    Number,
-
-    /// Sort by Name
-    /// Returns sorted T
-    Name,
-}
-
-impl Default for Sort {
-    fn default() -> Self {
-        Self::Number
-    }
-}
-
 /// Order the result list by ASC or DESC
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -35,38 +17,8 @@ impl Default for Order {
     }
 }
 
-/// Possible Filters for Database Table
-
-/// This list may change in future updates
-#[derive(Deserialize, Serialize)]
-pub struct BaseFilters {
-    pub sort: Option<Sort>,
-    pub order: Option<Order>,
-
-    pub from: Option<u64>,
-    pub to: Option<u64>,
-}
-
-impl Filters for BaseFilters {
-    fn sort(&self) -> Option<Sort> {
-        self.sort.clone()
-    }
-
-    fn order(&self) -> Option<Order> {
-        self.order.clone()
-    }
-
-    fn from(&self) -> Option<u64> {
-        self.from
-    }
-
-    fn to(&self) -> Option<u64> {
-        self.to
-    }
-}
-
 pub trait Filters {
-    fn sort(&self) -> Option<Sort>;
+    fn sort(&self) -> Option<String>;
     fn order(&self) -> Option<Order>;
     fn from(&self) -> Option<u64>;
     fn to(&self) -> Option<u64>;

--- a/src/models_filter.rs
+++ b/src/models_filter.rs
@@ -1,7 +1,9 @@
-use crate::schema::quran_surahs::{table as quran_surahs_table, BoxedQuery};
+use crate::models::QuranMushaf;
+use crate::schema::mushafs::{table as quran_mushafs_table, BoxedQuery as MushafBoxedQuery};
+use crate::schema::quran_surahs::{table as quran_surahs_table, BoxedQuery as SurahBoxedQuery};
 use crate::{
     error::RouterError,
-    filter::{Filter, Filters, Order, Sort},
+    filter::{Filter, Filters, Order},
     models::QuranSurah,
 };
 use diesel::pg::Pg;
@@ -25,24 +27,61 @@ use diesel::{prelude::*, query_dsl::methods::BoxedDsl};
 //
 // Also there is a macro simular for what we want in macros.rs file
 impl Filter for QuranSurah {
-    type Output = Result<BoxedQuery<'static, Pg>, RouterError>;
+    type Output = Result<SurahBoxedQuery<'static, Pg>, RouterError>;
 
     fn filter(filters: Box<dyn Filters>) -> Self::Output {
         use crate::schema::quran_surahs::dsl::*;
 
         let mut _query = quran_surahs_table.into_boxed();
 
-        _query = match filters.sort().unwrap_or_default() {
-            Sort::Name => match filters.order().unwrap_or_default() {
-                Order::Asc => quran_surahs.order(name.asc()).internal_into_boxed(),
-                Order::Desc => quran_surahs.order(name.desc()).internal_into_boxed(),
+        _query = match filters.sort() {
+            Some(sort_str) => match sort_str.as_str() {
+                "name" => Ok(match filters.order().unwrap_or_default() {
+                    Order::Asc => quran_surahs.order(name.asc()).internal_into_boxed(),
+                    Order::Desc => quran_surahs.order(name.desc()).internal_into_boxed(),
+                }),
+
+                "number" => Ok(match filters.order().unwrap_or_default() {
+                    Order::Asc => quran_surahs.order(number.asc()).internal_into_boxed(),
+                    Order::Desc => quran_surahs.order(number.desc()).internal_into_boxed(),
+                }),
+                _ => Err(RouterError::BadRequest("No such sort value!".to_string())),
             },
 
-            Sort::Number => match filters.order().unwrap_or_default() {
-                Order::Asc => quran_surahs.order(number.asc()).internal_into_boxed(),
-                Order::Desc => quran_surahs.order(number.desc()).internal_into_boxed(),
-            },
+            None => Ok(quran_surahs.internal_into_boxed()),
+        }?;
+
+        _query = match filters.to() {
+            Some(limit) => _query
+                .limit(limit as i64)
+                .offset(filters.from().unwrap_or_default() as i64),
+            None => _query.offset(filters.from().unwrap_or_default() as i64),
         };
+
+        Ok(_query)
+    }
+}
+
+impl Filter for QuranMushaf {
+    type Output = Result<MushafBoxedQuery<'static, Pg>, RouterError>;
+
+    fn filter(filters: Box<dyn Filters>) -> Self::Output {
+        use crate::schema::mushafs::dsl::*;
+
+        let mut _query = quran_mushafs_table.into_boxed();
+
+        _query = match filters.sort() {
+            Some(sort_str) => match sort_str.as_str() {
+                "name" => Ok(match filters.order().unwrap_or_default() {
+                    Order::Asc => mushafs.order(name.asc()).internal_into_boxed(),
+                    Order::Desc => mushafs.order(name.desc()).internal_into_boxed(),
+                }),
+
+                _ => Err(RouterError::BadRequest("No such sort value!".to_string())),
+            },
+
+            None => Ok(mushafs.internal_into_boxed()),
+        }?;
 
         _query = match filters.to() {
             Some(limit) => _query

--- a/src/models_filter.rs
+++ b/src/models_filter.rs
@@ -1,10 +1,10 @@
-use crate::models::QuranMushaf;
+use crate::models::{QuranMushaf, QuranSurah, Translation};
 use crate::schema::mushafs::{table as quran_mushafs_table, BoxedQuery as MushafBoxedQuery};
 use crate::schema::quran_surahs::{table as quran_surahs_table, BoxedQuery as SurahBoxedQuery};
+use crate::schema::translations::{table as translations_table, BoxedQuery as TranslationBoxedQuery};
 use crate::{
     error::RouterError,
     filter::{Filter, Filters, Order},
-    models::QuranSurah,
 };
 use diesel::pg::Pg;
 use diesel::{prelude::*, query_dsl::methods::BoxedDsl};
@@ -45,7 +45,11 @@ impl Filter for QuranSurah {
                     Order::Asc => quran_surahs.order(number.asc()).internal_into_boxed(),
                     Order::Desc => quran_surahs.order(number.desc()).internal_into_boxed(),
                 }),
-                _ => Err(RouterError::BadRequest("No such sort value!".to_string())),
+
+                value => Err(RouterError::BadRequest(format!(
+                    "Sort value {} is not possible!",
+                    value
+                ))),
             },
 
             None => Ok(quran_surahs.internal_into_boxed()),
@@ -77,10 +81,48 @@ impl Filter for QuranMushaf {
                     Order::Desc => mushafs.order(name.desc()).internal_into_boxed(),
                 }),
 
-                _ => Err(RouterError::BadRequest("No such sort value!".to_string())),
+                value => Err(RouterError::BadRequest(format!(
+                    "Sort value {} is not possible!",
+                    value
+                ))),
             },
 
             None => Ok(mushafs.internal_into_boxed()),
+        }?;
+
+        _query = match filters.to() {
+            Some(limit) => _query
+                .limit(limit as i64)
+                .offset(filters.from().unwrap_or_default() as i64),
+            None => _query.offset(filters.from().unwrap_or_default() as i64),
+        };
+
+        Ok(_query)
+    }
+}
+
+impl Filter for Translation {
+    type Output = Result<TranslationBoxedQuery<'static, Pg>, RouterError>;
+
+    fn filter(filters: Box<dyn Filters>) -> Self::Output {
+        use crate::schema::translations::dsl::*;
+
+        let mut _query = translations_table.into_boxed();
+
+        _query = match filters.sort() {
+            Some(sort_str) => match sort_str.as_str() {
+                "createTime" => Ok(match filters.order().unwrap_or_default() {
+                    Order::Asc => translations.order(created_at.asc()).internal_into_boxed(),
+                    Order::Desc => translations.order(created_at.desc()).internal_into_boxed(),
+                }),
+
+                value => Err(RouterError::BadRequest(format!(
+                    "Sort value {} is not possible!",
+                    value
+                ))),
+            },
+
+            None => Ok(translations.internal_into_boxed()),
         }?;
 
         _query = match filters.to() {

--- a/src/routers/quran/mushaf/mod.rs
+++ b/src/routers/quran/mushaf/mod.rs
@@ -6,6 +6,8 @@ pub mod mushaf_view;
 
 use serde::Deserialize;
 
+use crate::filter::{Order, Filters};
+
 #[derive(Deserialize)]
 pub struct SimpleMushaf {
     short_name: String,
@@ -14,3 +16,29 @@ pub struct SimpleMushaf {
     bismillah_text: Option<String>,
 }
 
+#[derive(Deserialize)]
+pub struct MushafListQuery {
+    sort: Option<String>,
+    order: Option<Order>,
+
+    from: Option<u64>,
+    to: Option<u64>,
+}
+
+impl Filters for MushafListQuery {
+    fn sort(&self) -> Option<String> {
+        self.sort.clone()
+    }
+
+    fn order(&self) -> Option<Order> {
+        self.order.clone()
+    }
+
+    fn from(&self) -> Option<u64> {
+        self.from
+    }
+
+    fn to(&self) -> Option<u64> {
+        self.to
+    }
+}

--- a/src/routers/quran/mushaf/mod.rs
+++ b/src/routers/quran/mushaf/mod.rs
@@ -13,3 +13,4 @@ pub struct SimpleMushaf {
     source: String,
     bismillah_text: Option<String>,
 }
+

--- a/src/routers/quran/mushaf/mushaf_list.rs
+++ b/src/routers/quran/mushaf/mushaf_list.rs
@@ -1,18 +1,23 @@
 use crate::error::RouterError;
+use crate::filter::Filter;
 use crate::models::QuranMushaf;
 use crate::DbPool;
 use actix_web::web;
 use diesel::prelude::*;
 
-/// Get the lists of mushafs
-pub async fn mushaf_list(pool: web::Data<DbPool>) -> Result<web::Json<Vec<QuranMushaf>>, RouterError> {
-    use crate::schema::mushafs::dsl::*;
+use super::MushafListQuery;
 
+/// Get the lists of mushafs
+pub async fn mushaf_list(
+    pool: web::Data<DbPool>,
+    web::Query(query): web::Query<MushafListQuery>,
+) -> Result<web::Json<Vec<QuranMushaf>>, RouterError> {
     web::block(move || {
         let mut conn = pool.get().unwrap();
 
         // Get the list of mushafs from the database
-        let quran_mushafs = mushafs.load::<QuranMushaf>(&mut conn)?;
+        let quran_mushafs =
+            QuranMushaf::filter(Box::from(query))?.load::<QuranMushaf>(&mut conn)?;
 
         Ok(web::Json(quran_mushafs))
     })

--- a/src/routers/quran/surah/mod.rs
+++ b/src/routers/quran/surah/mod.rs
@@ -5,7 +5,7 @@ pub mod surah_list;
 pub mod surah_view;
 
 use crate::{
-    filter::{Filters, Order, Sort},
+    filter::{Filters, Order},
     models::QuranWord,
 };
 use serde::{Deserialize, Serialize};
@@ -71,7 +71,7 @@ pub struct GetSurahQuery {
 pub struct SurahListQuery {
     mushaf: String,
 
-    sort: Option<Sort>,
+    sort: Option<String>,
     order: Option<Order>,
 
     from: Option<u64>,
@@ -79,7 +79,7 @@ pub struct SurahListQuery {
 }
 
 impl Filters for SurahListQuery {
-    fn sort(&self) -> Option<Sort> {
+    fn sort(&self) -> Option<String> {
         self.sort.clone()
     }
 

--- a/src/routers/translation/mod.rs
+++ b/src/routers/translation/mod.rs
@@ -1,15 +1,17 @@
 pub mod translation_add;
 pub mod translation_delete;
-pub mod translation_view;
-pub mod translation_list;
 pub mod translation_edit;
+pub mod translation_list;
+pub mod translation_text_delete;
 pub mod translation_text_modify;
 pub mod translation_text_view;
-pub mod translation_text_delete;
+pub mod translation_view;
 
-use serde::{Serialize, Deserialize};
 use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+use crate::filter::{Filters, Order};
 
 #[derive(Serialize, Deserialize)]
 pub struct SimpleTranslation {
@@ -23,4 +25,34 @@ pub struct SimpleTranslation {
 pub struct SimpleTranslationText {
     pub ayah_uuid: Uuid,
     pub text: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TranslationListQuery {
+    mushaf: String,
+    master_account: Option<Uuid>,
+
+    sort: Option<String>,
+    order: Option<Order>,
+
+    from: Option<u64>,
+    to: Option<u64>,
+}
+
+impl Filters for TranslationListQuery {
+    fn sort(&self) -> Option<String> {
+        self.sort.clone()
+    }
+
+    fn order(&self) -> Option<Order> {
+        self.order.clone()
+    }
+
+    fn from(&self) -> Option<u64> {
+        self.from
+    }
+
+    fn to(&self) -> Option<u64> {
+        self.to
+    }
 }

--- a/src/routers/translation/translation_list.rs
+++ b/src/routers/translation/translation_list.rs
@@ -1,20 +1,23 @@
 use crate::error::RouterError;
+use crate::filter::Filter;
 use crate::models::Translation;
 use crate::DbPool;
 use actix_web::web;
 use diesel::prelude::*;
 
+use super::TranslationListQuery;
+
 /// Returns the list of translations
 pub async fn translation_list(
     pool: web::Data<DbPool>,
+    web::Query(query): web::Query<TranslationListQuery>,
 ) -> Result<web::Json<Vec<Translation>>, RouterError> {
-    use crate::schema::translations::dsl::*;
-
     let result = web::block(move || {
         let mut conn = pool.get().unwrap();
 
         // Get the list of translations from the database
-        let translations_list = translations.load::<Translation>(&mut conn)?;
+        let translations_list =
+            Translation::filter(Box::from(query))?.load::<Translation>(&mut conn)?;
 
         Ok(web::Json(translations_list))
     })


### PR DESCRIPTION
New Changes:
1. The `Sort` enum removed, more technical details in 0ece90e53de3a023e9a5939b102a73e079a811b2
2. `Filters` now works in `/mushaf` and `/translation`
3. Better error handling for nonexisting Sort