### PR TITLE
Minor changes to models filter and translation_list router

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -419,8 +419,9 @@ pub struct NewPermissionCondition {
     pub value: String,
 }
 
-#[derive(Deserialize, Serialize, Clone, Validate, Identifiable, Queryable, Debug, Selectable)]
+#[derive(Deserialize, Serialize, Clone, Validate, Identifiable, Queryable, Debug, Selectable, Associations)]
 #[diesel(table_name = translations)]
+#[diesel(belongs_to(Account, foreign_key = translator_account_id))]
 pub struct Translation {
     #[serde(skip_serializing)]
     pub id: i32,

--- a/src/routers/translation/translation_list.rs
+++ b/src/routers/translation/translation_list.rs
@@ -43,7 +43,7 @@ pub async fn translation_list(
             .filter(language.eq(lang))
             .filter(translation_mushaf_id.eq(mushafid))
             .select(Translation::as_select())
-            .load(&mut conn)?;
+            .get_results(&mut conn)?;
         //.filter(translator_account_id.eq_any::<Vec<i32>>(master_account))
 
         Ok(web::Json(translations_list))


### PR DESCRIPTION
Minor changes to models filter and translation_list router.

```rust
pub type TranslationBoxedQueryType = IntoBoxed<
    'static,
    InnerJoin<
        InnerJoin<translations_table, mushafs::table>,
        InnerJoin<app_accounts::table, app_user_names::table>,
    >,
    Pg,
>;
```
This is a new translation filter return type.