### PR TITLE
Error handling added to AuthZ and AuthN middlewares

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,16 +36,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d223b13fd481fc0d1f83bb12659ae774d9e3601814c68a0bc539731698cca743"
+checksum = "4eb9843d84c775696c37d9a418bbb01b932629d01870722c0f13eb3f95e2536d"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64 0.21.5",
+ "base64 0.22.1",
  "bitflags 2.3.3",
  "brotli",
  "bytes",
@@ -85,13 +85,15 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
+ "cfg-if",
  "http",
  "regex",
+ "regex-lite",
  "serde",
  "tracing",
 ]
@@ -147,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.5.1"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a6556ddebb638c2358714d853257ed226ece6023ef9364f23f0c70737ea984"
+checksum = "5d6316df3fa569627c98b12557a8b6ff0674e5be4bb9b5e4ae2550ddb4964ed6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -176,6 +178,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -187,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1f50ebbb30eca122b188319a4398b3f7bb4a8cdf50ecfb73bfc6a3c3ce54f5"
+checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -314,9 +317,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -341,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.4"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -352,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.3.2"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1408,6 +1411,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.4.21"
 env_logger = "0.10.0"
 auth_n = { path = "authN" }
 auth_z = { path = "authZ" }
-actix-web = "4.5.0"
+actix-web = "4.7.0"
 actix-cors = "0.6.4"
 diesel = { version = "2.0.4", features = [
     "postgres",

--- a/authN/Cargo.toml
+++ b/authN/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 sha2 = "0.10.6"
-actix-web = "4"
+actix-web = "4.7.0"
 actix-utils = "3.0.1"
 async-trait = "0.1.68"
 futures-util = { version = "0.3.7", default-features = false, features = ["std"] }

--- a/authZ/Cargo.toml
+++ b/authZ/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
-actix-web = "4"
+actix-web = "4.7.0"
 actix-utils = "3.0.1"
 async-trait = "0.1.68"
 futures-util = { version = "0.3.7", default-features = false, features = ["std"] }

--- a/authZ/src/lib.rs
+++ b/authZ/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod middleware;
 
+use actix_web::ResponseError;
 use async_trait::async_trait;
 
 #[async_trait]
@@ -22,7 +23,14 @@ pub trait CheckPermission {
     /// Check if the permissions are valid
     ///
     /// This args will passed from the Middleware
-    async fn check(&self, subject: Option<u32>, path: ParsedPath, method: String) -> bool;
+    ///
+    /// The Err will be sent as response when permission denied
+    async fn check(
+        &self,
+        subject: Option<u32>,
+        path: ParsedPath,
+        method: String,
+    ) -> Result<(), Box<dyn ResponseError>>;
 }
 
 #[async_trait]

--- a/authZ/src/middleware.rs
+++ b/authZ/src/middleware.rs
@@ -109,18 +109,20 @@ where
         let path = ParsedPath::from(url_as_str);
 
         Box::pin(async move {
-            if permission
+            match permission
                 .check(subject, path, req.method().to_string())
                 .await
             {
-                let res = service.call(req).await?;
+                Ok(()) => {
+                    let res = service.call(req).await?;
 
-                return Ok(res);
+                    return Ok(res);
+                }
+
+                Err(error) => {
+                    return Err(Error::from(error));
+                }
             }
-
-            return Err(Error::from(AccessDeniedError::with_message(
-                "You don't have access to this resource!",
-            )));
         })
     }
 }

--- a/error_codes.json
+++ b/error_codes.json
@@ -54,5 +54,17 @@
     "FILTER_SORT_VALUE_NOT_DEFINED": {
         "status_code": 404,
         "message": "Filter sort value is not defined!"
+    },
+    "AUTHN_TOKEN_NOT_FOUND": {
+        "status_code": 401,
+        "message": "Token required!"
+    },
+    "AUTHN_TOKEN_INVALID": {
+        "status_code": 401,
+        "message": "Token invalid!"
+    },
+    "AUTHZ_PERMISSION_DENIED": {
+        "status_code": 403,
+        "message": "Permission denied!"
     }
 }

--- a/src/routers/account/mod.rs
+++ b/src/routers/account/mod.rs
@@ -12,7 +12,7 @@ pub const MAX_RANDOM_CODE: i32 = 999999;
 /// Get deference between Current time and past_time
 pub fn time_deference(past_time: NaiveDateTime) -> Duration {
     let current_date = Utc::now();
-    let past_date_time = DateTime::<Utc>::from_utc(past_time, Utc);
+    let past_date_time = DateTime::<Utc>::from_naive_utc_and_offset(past_time, Utc);
 
     current_date.signed_duration_since(past_date_time)
 }

--- a/src/token_checker.rs
+++ b/src/token_checker.rs
@@ -1,5 +1,7 @@
-use crate::{models::Token, DbPool};
-use actix_web::web;
+use std::sync::Arc;
+
+use crate::{error::RouterError, models::Token, DbPool};
+use actix_web::{web, ResponseError};
 use async_trait::async_trait;
 use auth_n::token::{HashBuilder, TokenChecker};
 use diesel::prelude::*;
@@ -19,11 +21,13 @@ impl UserIdFromToken {
 
 #[async_trait]
 impl TokenChecker<u32> for UserIdFromToken {
-    async fn get_user_id(&self, request_token: &str) -> Option<u32> {
+    async fn get_user_id(&self, request_token: &str) -> Result<u32, Box<dyn ResponseError>> {
         use crate::schema::app_tokens::dsl::*;
 
         // Token as bytes
         let token_bytes: Vec<u8> = request_token.bytes().collect();
+
+        let token_invalid_error = Box::new(RouterError::from_predefined("AUTHN_TOKEN_INVALID"));
 
         let mut conn = self.db_pool.get().unwrap();
 
@@ -46,16 +50,25 @@ impl TokenChecker<u32> for UserIdFromToken {
 
         // Is there any token we found ?
         if token.is_empty() {
-            return None;
+            token_invalid_error.log_to_db(Arc::new(self.db_pool.clone()));
+            return Err(token_invalid_error);
         }
 
         let last_token = token.get(0).unwrap();
 
         // Return None for teminated token
         if last_token.terminated {
-            return None;
+            token_invalid_error.log_to_db(Arc::new(self.db_pool.clone()));
+            return Err(token_invalid_error);
         }
 
-        Some(last_token.user_id as u32)
+        Ok(last_token.user_id as u32)
+    }
+
+    async fn token_not_found_error(&self) -> Box<dyn ResponseError> {
+        Box::new(
+            RouterError::from_predefined("AUTHN_TOKEN_NOT_FOUND")
+                .log_to_db(Arc::new(self.db_pool.clone())),
+        )
     }
 }


### PR DESCRIPTION
Changes:

1. Updated to the latest actix-web stable version (This was required due to a `From` impl we wanted to use and was available in `4.7.0` version of actix-web
2. New predefined errors added to `error_codes.json` file.
3. Removed deprecated `chrono` function call at `src/routers/account/mod.rs` [49869e4](https://github.com/NatiqQuran/nq-api/pull/159/commits/49869e479643345050c347b04ac2697ce9e46b24)